### PR TITLE
ci: Add CI with GitHub Actions to test and publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI/CD
+
+on:
+  push:
+  schedule:
+  - cron:  '1 0 * * *'
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Build Docker image
+      run: |
+        docker build . \
+          --file Dockerfile \
+          --tag coreweave/fah-gpu:$GITHUB_SHA \
+          --compress
+        docker images
+    - name: Build GPU only Docker image
+      run: |
+        docker build . \
+          --file Dockerfile.gpuonly \
+          --tag coreweave/fah-gpu:gpuonly-$GITHUB_SHA \
+          --compress
+        docker images

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI/CD
 
 on:
   push:
+  pull_request:
   schedule:
   - cron:  '1 0 * * *'
 
@@ -13,16 +14,20 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Build Docker image
-      run: |
-        docker build . \
-          --file Dockerfile \
-          --tag coreweave/fah-gpu:$GITHUB_SHA \
-          --compress
-        docker images
+      uses: docker/build-push-action@v1
+      with:
+        repository: coreweave/fah-gpu
+        dockerfile: Dockerfile
+        tag_with_sha: true
+        tag_with_ref: true
+        push: false
     - name: Build GPU only Docker image
-      run: |
-        docker build . \
-          --file Dockerfile.gpuonly \
-          --tag coreweave/fah-gpu:gpuonly-$GITHUB_SHA \
-          --compress
-        docker images
+      uses: docker/build-push-action@v1
+      with:
+        repository: coreweave/fah-gpu
+        dockerfile: Dockerfile.gpuonly
+        tag_with_sha: true
+        tag_with_ref: true
+        push: false
+    - name: List built images
+      run: docker images

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
         tag_with_sha: true
         tag_with_ref: true
         push: false
+    - name: List built image
+      run: docker images
     - name: Build GPU only Docker image
       uses: docker/build-push-action@v1
       with:
@@ -29,5 +31,5 @@ jobs:
         tag_with_sha: true
         tag_with_ref: true
         push: false
-    - name: List built images
+    - name: List built GPU image
       run: docker images

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Build and Publish to Registry
-      if: "! ${{ startsWith(github.ref, 'refs/tags/') }}"
+      if: "!(startsWith(github.ref, 'refs/tags/'))"
       uses: docker/build-push-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
@@ -24,7 +24,7 @@ jobs:
         dockerfile: Dockerfile
         tags: latest,7.5.1
     - name: Build and Publish GPU Only to Registry
-      if: "! ${{ startsWith(github.ref, 'refs/tags/') }}"
+      if: "!(startsWith(github.ref, 'refs/tags/'))"
       uses: docker/build-push-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
@@ -33,7 +33,7 @@ jobs:
         dockerfile: Dockerfile.gpuonly
         tags: 7.5.1-gpuonly
     - name: Build and Publish to Registry with Release Tag
-      if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,44 @@
+name: Publish Docker Images
+
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - v*
+
+jobs:
+  build-and-publish:
+    name: Build and publish GPU Docker images to Docker Hub
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Build and Publish to Registry
+      if: "! ${{ startsWith(github.ref, 'refs/tags/') }}"
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: coreweave/fah-gpu
+        dockerfile: Dockerfile
+        tags: latest,7.5.1
+    - name: Build and Publish GPU Only to Registry
+      if: "! ${{ startsWith(github.ref, 'refs/tags/') }}"
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: coreweave/fah-gpu
+        dockerfile: Dockerfile.gpuonly
+        tags: 7.5.1-gpuonly
+    - name: Build and Publish to Registry with Release Tag
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: coreweave/fah-gpu
+        dockerfile: Dockerfile
+        tags: latest,latest-stable,7.5.1
+        tag_with_ref: true


### PR DESCRIPTION
Add CI using GitHub Actions to test the build on each push event and [deploy the build to Docker Hub](https://github.com/docker/build-push-action) when a PR is merged to `master` with the tags `latest` and `7.5.1` for the `Dockerfile` build (if the push that triggers the build is a tag push then the image will also be labeled with `latest-stable` and the tag) and the `7.5.1-gpuonly` for the  `Dockerfile.gpuonly` build.

This [requires the following secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets) be added to the GitHub repo:

- `DOCKER_USERNAME`
- `DOCKER_PASSWORD`

You already have an automated build with Docker Hub setup for `latest`. This isn't an issue, but what I usually do is change the rule to name the _slow_ Docker Hub build as `dockerhub-build` so that I don't get confused by differing SHAs.